### PR TITLE
add async tests for Model.apply

### DIFF
--- a/test/bacon.model.spec.coffee
+++ b/test/bacon.model.spec.coffee
@@ -73,32 +73,26 @@ describe "Model.apply", ->
     expect(values).to.deep.equal([1, 2, 4, 8])
   it "Applies given async stream of functions to the Model", (done) ->
     b = lib.Model(1)
-    b.onValue((val) ->
-      if (val == 2) then done()
-    )
-    b.apply(Bacon.fromBinder((sink) ->
+    b.onValue (val) ->
+      if val == 2 then done()
+    b.apply Bacon.fromBinder (sink) ->
       setTimeout((->
         sink(twice)
       ), 500)
       ->
-    ))
   it "Applies given node-stream stream of functions to the Model", (done) ->
     b = lib.Model(1)
-    b.onValue((val) ->
-      if (val == 3) then done()
-    )
-    b.apply(Bacon.fromBinder((sink) ->
+    b.onValue (val) ->
+      if val == 3 then done()
+    b.apply Bacon.fromBinder (sink) ->
       S = require('stream').Transform
       s = new S(objectMode: true)
-      s.on('readable', ->
-        mult = parseInt(s.read())
-        f = (x) -> x * mult
-        sink(f)
-      )
+      s.on 'readable', ->
+        mult = parseInt s.read()
+        sink((x) -> x * mult)
       s.push(3)
       s.push(null)
       ->
-    ))
 
 describe "Model.addSource", ->
   it "connects new input stream", ->


### PR DESCRIPTION
hi! thanks for `bacon.model`. :)

i wrote some tests for `Model.apply` that demonstrate using async streams.

the reason i wrote these tests is because i'm having an issue using `bacon.model` in a [`bacon.level`](https://github.com/holonomy/bacon.level) plugin i began working on. i'm clearly doing something wrong as this plugin's tests pass and my plugin's tests fail, but i'm having trouble figuring out what is wrong. i'm a total newbie with bacon so if anyone could help that would be greatly appreciated.

cheers!
