### PR TITLE
Use tilde for Bacon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "MIT"
   ],
   "dependencies": {
-    "baconjs": "0.7.6"
+    "baconjs": "~0.7.6"
   },
   "devDependencies": {
     "coffee-script": "1.4.0",


### PR DESCRIPTION
Currently bacon.jquery isn't usable with Browserify, as that specifies baconjs ~0.7.8 and this asks for 0.7.6 exactly, so you end up with two copies of Bacon, one with bacon.model and the other with bacon.jquery, and when bacon.jquery needs Bindings it barfs.
