### PR TITLE
Bacon.Model.Combine to enumerate its own properties only

### DIFF
--- a/src/bacon.model.coffee
+++ b/src/bacon.model.coffee
@@ -81,7 +81,7 @@ init = (Bacon) ->
     else
       initValue = if template instanceof Array then [] else {}
       model = Model(initValue)
-      for key, value of template
+      for own key, value of template
         lens = Lens.objectLens(key)
         lensedModel = model.lens(lens)
         lensedModel.bind(Model.combine(value))


### PR DESCRIPTION
Updated the iteration inside combine to ensure inherited properties are avoided. This happens in IE environments due to the use of Array polyfill, which is inevitable these days.
